### PR TITLE
Fix error in proof

### DIFF
--- a/II/probability_and_measure.tex
+++ b/II/probability_and_measure.tex
@@ -197,7 +197,7 @@ The idea of Lebesgue is to use countable covers by boxes.
   \]
   wlog we may assume that the side lengths of each \(B_n\) are \(< \frac{\alpha}{2}\), where
   \[
-    \alpha = \inf \{\norm{x - y}_1: x \in A, y \in B\} > 0.
+    \alpha = \inf \{\norm{x - y}_\infty: x \in A, y \in B\} > 0.
   \]
   where the inequality comes from the fact that \(A\) and \(B\) are compact and thus closed. wlog we may discard the \(B_n\)'s that do not interesect \(A \cup B\). Then by construction
   \[


### PR DESCRIPTION
We need the L-infinity norm, rather than the L-1 norm, in the definition of alpha. If the L-1 norm is used then a B_n could intersect both A and B if d>2.